### PR TITLE
Migrate to FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - **SQL Explorer**: Connect to SQLite (or other databases) and ask questions via SQL or plain English  
 - **Pandas Agent**: Upload CSV/Excel and run advanced analyses with memory support  
 - **Modular Architecture**: Separate `agents/`, `config/`, `scripts/`, and `utils/` folders for scalability  
-- **Streamlit UI**: One unified dashboard (`main.py`) with three tabs for Docs, SQL, and Pandas  
+- **FastAPI Backend**: REST endpoints for Docs, SQL, and Pandas
 
 ---
 
@@ -48,15 +48,10 @@ COHERE_API_KEY=<your_cohere_key>  # if using reranking
 
 ### Run the App
 ```bash
-streamlit run main.py
+uvicorn app:app --reload
 ```
 
-Then open the URL shown in your browser. You'll see three tabs:
-- **Docs & Chat** – Upload documents to populate the vector store, then chat
-- **SQL Explorer** – Connect/load a SQLite DB and converse via SQL
-- **Pandas Agent** – Upload tabular files and perform analysis
-
-## 🔍 Scripts for Testing
+Then open http://localhost:8000/docs to explore the API.
 We include smoke-test scripts under `scripts/`:
 - `run_database_agent.py`: Verifies the SQL agent can list tables and run queries
 - `run_unstructured_agent.py`: Tests the HybridQAChain against sample queries
@@ -80,7 +75,7 @@ Analytiq/
 ├── data/                    # Persistent storage (vector DB, sample DB)
 ├── scripts/                 # Smoke-test and evaluation scripts
 ├── utils/                   # Shared helpers (session storage, prompts)
-├── main.py                  # Streamlit entrypoint with 3-tab UI
+├── app.py                  # FastAPI entrypoint
 ├── requirements.txt         # Python dependencies
 └── README.md                # This file
 ```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,110 @@
+from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.responses import JSONResponse
+from typing import List
+from io import BytesIO
+from langchain.docstore.document import Document
+import pandas as pd
+
+from agents.unstructured_agent.document_loaders import (
+    load_pdf, load_docx, load_excel, load_csv, text_splitter
+)
+from agents.unstructured_agent.vector_store import get_vector_store
+from agents.unstructured_agent.agent import HybridQAChain
+from agents.database_agent.agent import build_sql_agent_with_memory
+from agents.pandas_agent.agent import build_pandas_agent_with_memory
+
+app = FastAPI(title="Analytiq API")
+
+# In-memory state (very basic) -----------------------------------------
+vector_store = get_vector_store()
+sql_agent = None
+pandas_agent = None
+
+# ----------------------------------------------------------------------
+@app.post("/docs/upload")
+async def upload_docs(files: List[UploadFile] = File(...)):
+    """Upload documents into the vector store."""
+    for file in files:
+        data = await file.read()
+        buf = BytesIO(data)
+        ext = file.filename.rsplit(".", 1)[-1].lower()
+        if ext == "pdf":
+            docs = load_pdf(buf, file.filename)
+        elif ext == "docx":
+            docs = load_docx(buf, file.filename)
+        elif ext == "xlsx":
+            docs = load_excel(buf, file.filename)
+        elif ext == "csv":
+            docs = load_csv(buf, file.filename)
+        else:
+            text = data.decode("utf-8", errors="ignore")
+            docs = [Document(page_content=text, metadata={"source": file.filename})]
+        chunks = text_splitter.split_documents(docs)
+        vector_store.add_documents(chunks, batch_size=128)
+    vector_store.persist()
+    return {"status": "ok", "files": [f.filename for f in files]}
+
+
+@app.post("/docs/chat")
+async def chat_docs(question: str = Form(...),
+                    temperature: float = Form(0.0),
+                    top_k_vector: int = Form(10),
+                    top_k_rerank: int = Form(3),
+                    sheet_filter: str | None = Form(None)):
+    chain = HybridQAChain(
+        temperature=temperature,
+        top_k_vector=top_k_vector,
+        top_k_rerank=top_k_rerank,
+        sheet_filter=sheet_filter or None,
+    )
+    result = chain.run(question)
+    sources = [d.metadata.get("source", "") for d in result.get("source_documents", [])]
+    return {"answer": result.get("answer"), "sources": sources}
+
+
+@app.post("/sql/connect")
+async def connect_db(conn_str: str = Form(...), temperature: float = Form(0.0)):
+    global sql_agent
+    sql_agent = build_sql_agent_with_memory(conn_str, temperature=temperature)
+    return {"status": "connected"}
+
+
+@app.post("/sql/query")
+async def run_sql(query: str = Form(...)):
+    if sql_agent is None:
+        return JSONResponse({"error": "Connect first."}, status_code=400)
+    try:
+        res = sql_agent.run(query)
+        return {"result": str(res)}
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+@app.post("/pandas/upload")
+async def upload_tables(files: List[UploadFile] = File(...), temperature: float = Form(0.0)):
+    dfs = {}
+    for file in files:
+        data = await file.read()
+        buf = BytesIO(data)
+        name = file.filename
+        if name.lower().endswith(".csv"):
+            df = pd.read_csv(buf)
+            dfs[name] = {"Sheet1": df}
+        else:
+            sheets = pd.read_excel(buf, sheet_name=None)
+            dfs[name] = sheets
+    global pandas_agent
+    pandas_agent = build_pandas_agent_with_memory(dfs, temperature=temperature)
+    return {"status": "loaded", "files": list(dfs)}
+
+
+@app.post("/pandas/query")
+async def query_tables(question: str = Form(...)):
+    if pandas_agent is None:
+        return JSONResponse({"error": "Upload tables first."}, status_code=400)
+    try:
+        out = pandas_agent.run(question)
+        return {"result": str(out)}
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+


### PR DESCRIPTION
## Summary
- implement a basic FastAPI server in `app.py`
- update README with FastAPI instructions and revised project structure

## Testing
- `python -m py_compile app.py`
- `python -m py_compile agents/unstructured_agent/agent.py`
- `python -m py_compile agents/database_agent/agent.py agents/pandas_agent/agent.py`
- `python -m scripts.run_pandas_agent` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_683f5a7cecfc8329832604f996efa8eb